### PR TITLE
Support renew token

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -292,6 +292,7 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
+    "github.com/hashicorp/go-hclog",
     "github.com/hashicorp/go-plugin",
     "github.com/hashicorp/hcl",
     "github.com/hashicorp/vault/api",

--- a/cmd/server/vault-upstream-ca/main_test.go
+++ b/cmd/server/vault-upstream-ca/main_test.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"strings"
 	"testing"
 	"text/template"
@@ -34,6 +35,12 @@ const (
 type configParam struct {
 	Addr  string
 	Token string
+}
+
+func getTestLogger() *log.Logger {
+	logger := &log.Logger{}
+	logger.SetOutput(new(bytes.Buffer))
+	return logger
 }
 
 func getFakeConfigureRequestCertAuth(addr string) (*plugin.ConfigureRequest, error) {
@@ -126,6 +133,7 @@ func TestConfigureCertConfig(t *testing.T) {
 	defer s.Close()
 
 	p := New()
+	p.logger = getTestLogger()
 
 	ctx := context.Background()
 	req, err := getFakeConfigureRequestCertAuth(fmt.Sprintf("https://%v/", addr))
@@ -152,6 +160,7 @@ func TestConfigureTokenConfig(t *testing.T) {
 	defer s.Close()
 
 	p := New()
+	p.logger = getTestLogger()
 
 	ctx := context.Background()
 	req, err := getFakeConfigureRequestTokenAuth(fmt.Sprintf("https://%v/", addr), "test-token")
@@ -210,6 +219,7 @@ func TestSubmitCSR(t *testing.T) {
 	defer s.Close()
 
 	p := New()
+	p.logger = getTestLogger()
 	client, err := getFakeVaultClientWithCertAuth(addr, "test-auth", "test-pki")
 	if err != nil {
 		t.Error(err)
@@ -263,6 +273,7 @@ func TestSubmitCSRError(t *testing.T) {
 	defer s.Close()
 
 	p := New()
+	p.logger = getTestLogger()
 	client, err := getFakeVaultClientWithCertAuth(addr, "test-auth", "test-pki")
 	if err != nil {
 		t.Error(err)

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -1,0 +1,5 @@
+package common
+
+const (
+	PluginName = "vault"
+)

--- a/pkg/vault/renewer.go
+++ b/pkg/vault/renewer.go
@@ -1,0 +1,43 @@
+package vault
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	vapi "github.com/hashicorp/vault/api"
+)
+
+type Renew struct {
+	Logger  *log.Logger
+	renewer *vapi.Renewer
+}
+
+func NewRenew(client *vapi.Client, secret *vapi.Secret) (*Renew, error) {
+	renewer, err := client.NewRenewer(&vapi.RenewerInput{
+		Secret: secret,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize Renewer: %v", err)
+	}
+	return &Renew{
+		Logger:  log.New(os.Stderr, "", log.LstdFlags),
+		renewer: renewer,
+	}, nil
+}
+
+func (r *Renew) Run() {
+	go r.renewer.Renew()
+	defer r.renewer.Stop()
+
+	for {
+		select {
+		case err := <-r.renewer.DoneCh():
+			if err != nil {
+				r.Logger.Printf("failed to renew: %v\n", err.Error())
+			}
+		case renewal := <-r.renewer.RenewCh():
+			r.Logger.Printf("Successfully renewed: request_id=%v\n", renewal.Secret.RequestID)
+		}
+	}
+}

--- a/pkg/vault/vault_test.go
+++ b/pkg/vault/vault_test.go
@@ -8,11 +8,13 @@
 package vault
 
 import (
+	"bytes"
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"net/http"
 	"reflect"
 	"testing"
@@ -32,6 +34,12 @@ const (
 	testReqCN  = "test request"
 	testTTL    = ""
 )
+
+func getTestLogger() *log.Logger {
+	logger := &log.Logger{}
+	logger.SetOutput(new(bytes.Buffer))
+	return logger
+}
 
 func getTestCertPool(certPemPath string) (*x509.CertPool, error) {
 	wantPool := x509.NewCertPool()
@@ -79,6 +87,7 @@ func TestNewAuthenticatedClientWithCertAuth(t *testing.T) {
 	defer s.Close()
 
 	c := New(CERT)
+	c.Logger = getTestLogger()
 	cp := &ClientParams{
 		VaultAddr:      fmt.Sprintf("https://%v/", addr),
 		CACertPath:     caCert,
@@ -110,6 +119,7 @@ func TestNewAuthenticatedClientWithCertAuthError(t *testing.T) {
 	defer s.Close()
 
 	c := New(CERT)
+	c.Logger = getTestLogger()
 	cp := &ClientParams{
 		VaultAddr:      fmt.Sprintf("https://%v/", addr),
 		CACertPath:     caCert,
@@ -140,6 +150,7 @@ func TestNewAuthenticatedClientWithTokenAuth(t *testing.T) {
 	defer s.Close()
 
 	c := New(TOKEN)
+	c.Logger = getTestLogger()
 	cp := &ClientParams{
 		VaultAddr:      fmt.Sprintf("https://%v/", addr),
 		CACertPath:     caCert,
@@ -158,6 +169,7 @@ func TestNewAuthenticatedClientWithTokenAuth(t *testing.T) {
 
 func TestSetClientParams(t *testing.T) {
 	c := New(CERT)
+	c.Logger = getTestLogger()
 	c.clientParams.VaultAddr = "https://example.org/vault"
 	c.clientParams.CACertPath = "path/to/test-ca.pem"
 	c.clientParams.ClientCertPath = "path/to/client-cert.pem"
@@ -189,6 +201,7 @@ func TestSetClientParams(t *testing.T) {
 
 func TestConfigureTLSWithCertAuth(t *testing.T) {
 	c := New(CERT)
+	c.Logger = getTestLogger()
 	c.clientParams.CACertPath = caCert
 	c.clientParams.ClientCertPath = clientCert
 	c.clientParams.ClientKeyPath = clientKey
@@ -230,6 +243,7 @@ func TestConfigureTLSWithCertAuth(t *testing.T) {
 
 func TestConfigureTLSWithTokenAuth(t *testing.T) {
 	c := New(TOKEN)
+	c.Logger = getTestLogger()
 	c.clientParams.CACertPath = caCert
 	vConfig := vapi.DefaultConfig()
 
@@ -278,6 +292,7 @@ func TestSignIntermediate(t *testing.T) {
 	defer s.Close()
 
 	c := New(CERT)
+	c.Logger = getTestLogger()
 	c.clientParams.VaultAddr = fmt.Sprintf("https://%v/", addr)
 	c.clientParams.CACertPath = caCert
 	c.clientParams.ClientCertPath = clientCert
@@ -327,6 +342,7 @@ func TestSignIntermediateError(t *testing.T) {
 	defer s.Close()
 
 	c := New(CERT)
+	c.Logger = getTestLogger()
 	c.clientParams.VaultAddr = fmt.Sprintf("https://%v/", addr)
 	c.clientParams.CACertPath = caCert
 	c.clientParams.ClientCertPath = clientCert


### PR DESCRIPTION
This PR supports for token rotation, since plugin can't issue intermediate certificate when token is expired.