### PR TITLE
Support Go-Style time duration value as TTL

### DIFF
--- a/cmd/server/vault-upstream-ca/fixtures/invalid-ttl.hcl
+++ b/cmd/server/vault-upstream-ca/fixtures/invalid-ttl.hcl
@@ -1,9 +1,9 @@
-vault_addr  = "{{ .Addr }}"
+vault_addr  = "https://localhost"
 auth_method = "cert"
 tls_auth_mount_point = "test-auth"
 pki_mount_point = "test-pki"
 ca_cert_path = "../../../pkg/fake/fixtures/ca.pem"
-ttl = "1h"
+ttl = "600"
 cert_auth_config {
    client_cert_path = "../../../pkg/fake/fixtures/client.pem"
    client_key_path  = "../../../pkg/fake/fixtures/client-key.pem"

--- a/cmd/server/vault-upstream-ca/fixtures/token-auth-config.tpl
+++ b/cmd/server/vault-upstream-ca/fixtures/token-auth-config.tpl
@@ -3,6 +3,7 @@ auth_method = "token"
 tls_auth_mount_point = "test-auth"
 pki_mount_point = "test-pki"
 ca_cert_path = "../../../pkg/fake/fixtures/ca.pem"
+ttl = "1h"
 token_auth_config {
    token  = "{{ .Token }}"
 }

--- a/doc/vault-upstream-ca.md
+++ b/doc/vault-upstream-ca.md
@@ -12,7 +12,7 @@ The plugin accepts the following configuration options:
 | auth_mount_point | string |  | Name of mount point where TLS auth method is mounted | cert |
 | pki_mount_point  | string |  | Name of mount point where PKI secret engine is mounted | pki |
 | ca_cert_path     | string |  | Path to a CA certificate file that the client verifies the server certificate. PEM and DER is supported. | `${VAULT_CACERT}` |
-| ttl              | string |  | Request to issue a certificate with the specified TTL | |
+| ttl              | string |  | Request to issue a certificate with the specified TTL (Go-Style time duration value e.g., 1h)  | |
 | tls_skip_verify  | string |  | If true, vault client accepts any server certificates | false |
 | cert_auth_config | struct |  | Configuration parameters to use when auth method is "cert" | |
 | token_auth_config | struct | | Configuration parameters to use when auth method is "token" | |


### PR DESCRIPTION
**!! Breaking backward compatibility !!**

This PR supports go-style time duration value as TTL in plugin's configuration file.

