### PR TITLE
Fix Vault request parameter for sign-intermediate endpoint

### DIFF
--- a/cmd/server/vault-upstream-ca/main.go
+++ b/cmd/server/vault-upstream-ca/main.go
@@ -29,10 +29,6 @@ import (
 	"github.com/zlabjp/spire-vault-plugin/pkg/vault"
 )
 
-const (
-	CommonName = "spire-server"
-)
-
 // VaultPlugin implements UpstreamCA Plugin interface
 type VaultPlugin struct {
 	logger  *log.Logger
@@ -152,7 +148,7 @@ func (p *VaultPlugin) SubmitCSR(ctx context.Context, req *upstreamca.SubmitCSRRe
 		ttl = fmt.Sprintf("%d", int64(p.certTTL/time.Second))
 	}
 
-	signResp, err := p.vc.SignIntermediate(CommonName, ttl, pemData)
+	signResp, err := p.vc.SignIntermediate(ttl, pemData)
 	if err != nil {
 		return nil, fmt.Errorf("SubmitCSR request is failed: %v", err)
 	}

--- a/pkg/vault/vault_test.go
+++ b/pkg/vault/vault_test.go
@@ -303,7 +303,12 @@ func TestSignIntermediate(t *testing.T) {
 		t.Errorf("failed to prepare vault client: %v", err)
 	}
 
-	resp, err := vClient.SignIntermediate(testReqCN, testTTL, []byte(testReqCSR))
+	csrPEM, err := ioutil.ReadFile(testReqCSR)
+	if err != nil {
+		t.Errorf("failed to read csr data: %v", err)
+	}
+
+	resp, err := vClient.SignIntermediate(testTTL, csrPEM)
 	if err != nil {
 		t.Errorf("error from SignIntermediate(): %v", err)
 	} else if resp == nil {
@@ -353,7 +358,12 @@ func TestSignIntermediateError(t *testing.T) {
 		t.Errorf("failed to prepare vault client: %v", err)
 	}
 
-	_, err = vClient.SignIntermediate(testReqCN, testTTL, []byte(testReqCSR))
+	csrPEM, err := ioutil.ReadFile(testReqCSR)
+	if err != nil {
+		t.Errorf("failed to read csr data: %v", err)
+	}
+
+	_, err = vClient.SignIntermediate(testTTL, csrPEM)
 	if err == nil {
 		t.Error("error is empty")
 	}


### PR DESCRIPTION
This PR fixes request parameter for Vault.
The Subject field of a certificate issued by Vault is an unexpected result.

```
        Subject: CN=spire-server
```

if spire-server config is follow

```
    ca_subject = {
        country = ["US"],
        organization = ["SPIFFE"],
        common_name = "test",
    }
```

we expect like

```
        Subject:  CN=test, C=US, O=SPIFFE
```