### PR TITLE
Support AppRole Auth Method

### DIFF
--- a/cmd/server/vault-upstream-ca/fixtures/approle-auth-config.tpl
+++ b/cmd/server/vault-upstream-ca/fixtures/approle-auth-config.tpl
@@ -1,0 +1,9 @@
+vault_addr  = "{{ .Addr }}"
+pki_mount_point = "test-pki"
+ca_cert_path = "../../../pkg/fake/fixtures/ca.pem"
+ttl = "1h"
+approle_auth_config {
+   approle_auth_mount_point = "test-auth"
+   approle_id = "test-approle-id"
+   approle_secret_id  = "test-approle-secret-id"
+}

--- a/cmd/server/vault-upstream-ca/fixtures/cert-auth-config.tpl
+++ b/cmd/server/vault-upstream-ca/fixtures/cert-auth-config.tpl
@@ -1,10 +1,9 @@
 vault_addr  = "{{ .Addr }}"
-auth_method = "cert"
-tls_auth_mount_point = "test-auth"
 pki_mount_point = "test-pki"
 ca_cert_path = "../../../pkg/fake/fixtures/ca.pem"
 ttl = "1h"
 cert_auth_config {
+   tls_auth_mount_point = "test-auth"
    client_cert_path = "../../../pkg/fake/fixtures/client.pem"
    client_key_path  = "../../../pkg/fake/fixtures/client-key.pem"
 }

--- a/cmd/server/vault-upstream-ca/fixtures/invalid-ttl.hcl
+++ b/cmd/server/vault-upstream-ca/fixtures/invalid-ttl.hcl
@@ -1,6 +1,4 @@
 vault_addr  = "https://localhost"
-auth_method = "cert"
-tls_auth_mount_point = "test-auth"
 pki_mount_point = "test-pki"
 ca_cert_path = "../../../pkg/fake/fixtures/ca.pem"
 ttl = "600"

--- a/cmd/server/vault-upstream-ca/fixtures/token-auth-config.tpl
+++ b/cmd/server/vault-upstream-ca/fixtures/token-auth-config.tpl
@@ -1,6 +1,4 @@
 vault_addr  = "{{ .Addr }}"
-auth_method = "token"
-tls_auth_mount_point = "test-auth"
 pki_mount_point = "test-pki"
 ca_cert_path = "../../../pkg/fake/fixtures/ca.pem"
 ttl = "1h"

--- a/doc/vault-upstream-ca.md
+++ b/doc/vault-upstream-ca.md
@@ -7,31 +7,25 @@ The plugin accepts the following configuration options:
 
 | key | type | required | description | default |
 |:----|:-----|:---------|:------------|:--------|
-| auth_method | string | ✓ | The method used for authentication to Vault. ("token", "cert") | |
 | vault_addr  | string |   | A URL of Vault server. (e.g., https://vault.example.com:8443/) | `${VAULT_ADDR}` |
-| auth_mount_point | string |  | Name of mount point where TLS auth method is mounted | cert |
 | pki_mount_point  | string |  | Name of mount point where PKI secret engine is mounted | pki |
 | ca_cert_path     | string |  | Path to a CA certificate file that the client verifies the server certificate. PEM and DER is supported. | `${VAULT_CACERT}` |
 | ttl              | string |  | Request to issue a certificate with the specified TTL (Go-Style time duration value e.g., 1h)  | |
 | tls_skip_verify  | string |  | If true, vault client accepts any server certificates | false |
-| cert_auth_config | struct |  | Configuration parameters to use when auth method is "cert" | |
-| token_auth_config | struct | | Configuration parameters to use when auth method is "token" | |
+| cert_auth_config | struct |  | Configuration parameters to use TLS cert auth method | |
+| token_auth_config | struct | | Configuration parameters to use Token auth method | |
+| approle_auth_config | struct | | Configuration parameters to use AppRole auth method | |
 
-The Plugin now supports only **cert** and **token** auth method.
-**cert** method authenticates to Vault using the TLS client certificate, **token** method authenticates to Vault using the token in the HTTP Request header.
+The Plugin now supports **TLS certificate**, **Token** and **AppRole** authentication method.
+**TLS certificate** method authenticates to Vault using the TLS client certificate, **Token** method authenticates to Vault using the token in the HTTP Request header. **AppRole** method authenticates to Vault using RoleID and SecretID that are issued from Vault.
 
 **cert_auth_config**
 
 | key | type | required | description | default |
 |:----|:-----|:---------|:------------|:--------|
+| tls_auth_mount_point | string |  | Name of mount point where TLS auth method is mounted | cert |
 | client_cert_path | string | | Path to a client certificate file. PEM and DER is supported. | `${VAULT_CLIENT_CERT}` |
 | client_key_path  | string | | Path to a client private key file PEM and DER is supported. | `${VAULT_CLIENT_KEY}` |
-
-**token_auth_config**
-
-| key | type | required | description | default |
-|:----|:-----|:---------|:------------|:--------|
-| token | string | | Token string to set into "X-Vault-Token" header | `${VAULT_TOKEN}` |
 
 ```hcl
     UpstreamCA "vault" {
@@ -39,17 +33,22 @@ The Plugin now supports only **cert** and **token** auth method.
         plugin_checksum = "(SHOULD) sha256 of the plugin binary"
         plugin_data {
             vault_addr = "https://vault.example.org/"
-            auth_method = "cert"
-            tls_auth_mount_point = "test-tls-auth"
             pki_mount_point = "test-pki"
             ca_cert_path = "/path/to/ca-cert.pem"
             cert_auth_config {
+                tls_auth_mount_point = "test-tls-auth"
                 client_cert_path = "/path/to/client-cert.pem"
                 client_key_path  = "/path/to/client-key.pem"
             }
         }
     }
 ```
+**token_auth_config**
+
+| key | type | required | description | default |
+|:----|:-----|:---------|:------------|:--------|
+| token | string | | Token string to set into "X-Vault-Token" header | `${VAULT_TOKEN}` |
+
 
 ```hcl
     UpstreamCA "vault" {
@@ -57,11 +56,34 @@ The Plugin now supports only **cert** and **token** auth method.
         plugin_checksum = "(SHOULD) sha256 of the plugin binary"
         plugin_data {
             vault_addr = "https://vault.example.org/"
-            auth_method = "token"
             pki_mount_point = "test-pki"
             ca_cert_path = "/path/to/ca-cert.pem"
             token_auth_config {
                token = "<token>" // or specified by environment variables
+            }
+        }
+    }
+```
+**approle_auth_config**
+
+| key | type | required | description | default |
+|:----|:-----|:---------|:------------|:--------|
+| approle_auth_mount_point | string | | Name of mount point where AppRole auth method is mounted | approle |
+| approle_id |string | | An identifier of AppRole | `${VAULT_APPROLE_ID}` |
+| approle_secret_id | string | | A credential of AppRole | `${VAULT_APPROLE_SECRET_ID}` |
+
+```hcl
+    UpstreamCA "vault" {
+        plugin_cmd = "vault-upstream-ca binary"
+        plugin_checksum = "(SHOULD) sha256 of the plugin binary"
+        plugin_data {
+            vault_addr = "https://vault.example.org/"
+            pki_mount_point = "test-pki"
+            ca_cert_path = "/path/to/ca-cert.pem"
+            approle_auth_config {
+               approle_auth_mount_point = "my-approle-auth"
+               approle_id = "<Role ID>" // or specified by environment variables
+               approle_secret_id = "<Secret ID>" // or specified by environment variables
             }
         }
     }

--- a/pkg/fake/fixtures/approle-auth-response.json
+++ b/pkg/fake/fixtures/approle-auth-response.json
@@ -1,0 +1,18 @@
+{
+  "auth": {
+    "renewable": true,
+    "lease_duration": 1200,
+    "metadata": null,
+    "token_policies": [
+      "default"
+    ],
+    "accessor": "fd6c9a00-d2dc-3b11-0be5-af7ae0e1d374",
+    "client_token": "5b1a0318-679c-9c45-e5c6-d1b9a9035d49"
+  },
+  "warnings": null,
+  "wrap_info": null,
+  "data": null,
+  "lease_duration": 0,
+  "renewable": false,
+  "lease_id": ""
+}

--- a/pkg/fake/vault.go
+++ b/pkg/fake/vault.go
@@ -16,6 +16,7 @@ import (
 
 const (
 	defaultTLSAuthEndpoint          = "/v1/auth/cert/login"
+	defaultAppRoleAuthEndpoint      = "/v1/auth/approle/login"
 	defaultSignIntermediateEndpoint = "/v1/pki/root/sign-intermediate"
 
 	listenAddr = "127.0.0.1:0"
@@ -29,6 +30,10 @@ type VaultServerConfig struct {
 	TLSAuthReqHandler            func(code int, resp []byte) func(http.ResponseWriter, *http.Request)
 	TLSAuthResponseCode          int
 	TLSAuthResponse              []byte
+	AppRoleAuthReqEndpoint       string
+	AppRoleAuthReqHandler        func(code int, resp []byte) func(w http.ResponseWriter, r *http.Request)
+	AppRoleAuthResponseCode      int
+	AppRoleAuthResponse          []byte
 	SignIntermediateReqEndpoint  string
 	SignIntermediateReqHandler   func(code int, resp []byte) func(http.ResponseWriter, *http.Request)
 	SignIntermediateResponseCode int
@@ -41,6 +46,8 @@ func NewVaultServerConfig() *VaultServerConfig {
 		ListenAddr:                  listenAddr,
 		TLSAuthReqEndpoint:          defaultTLSAuthEndpoint,
 		TLSAuthReqHandler:           defaultReqHandler,
+		AppRoleAuthReqEndpoint:      defaultAppRoleAuthEndpoint,
+		AppRoleAuthReqHandler:       defaultReqHandler,
 		SignIntermediateReqEndpoint: defaultSignIntermediateEndpoint,
 		SignIntermediateReqHandler:  defaultReqHandler,
 	}
@@ -69,6 +76,7 @@ func (v *VaultServerConfig) NewTLSServer() (srv *httptest.Server, addr string, e
 
 	mux := http.NewServeMux()
 	mux.HandleFunc(v.TLSAuthReqEndpoint, v.TLSAuthReqHandler(v.TLSAuthResponseCode, v.TLSAuthResponse))
+	mux.HandleFunc(v.AppRoleAuthReqEndpoint, v.AppRoleAuthReqHandler(v.AppRoleAuthResponseCode, v.AppRoleAuthResponse))
 	mux.HandleFunc(v.SignIntermediateReqEndpoint, v.SignIntermediateReqHandler(v.SignIntermediateResponseCode, v.SignIntermediateResponse))
 
 	srv = httptest.NewUnstartedServer(mux)


### PR DESCRIPTION
This PR supports AppRole Auth Method to login HashiCorp Vault.

**break compatibility**
- Move `tls_auth_mount_point` parameter under the `tls_auth_config`. (Also fixed some typo of 
 paramete name `s/auth_mount_point/tls_auth_mount_point/g`)

**other changes**
- Remove `auth_method` parameter from config


