### PR TITLE
Go1.13

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,17 +2,11 @@
 
 ## Prerequisites
 
-- Go 1.12 or higher
+- Go 1.13 or higher
 
 ## Building
 
-We use `dep` for vendoring Go dependencies.
-If you add new dependencies, resolve dependencies as follows.
-
-```
-$ make vendor
-```
-
+We use Go Modules for vendoring Go dependencies. 
 And you can test and build codes as follows.
 
 ```

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/zlabjp/spire-vault-plugin
 
-go 1.12
+go 1.13
 
 require (
 	github.com/DataDog/datadog-go v3.4.0+incompatible // indirect
@@ -9,7 +9,6 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.2.0 // indirect
 	github.com/hashicorp/go-hclog v0.9.2
 	github.com/hashicorp/go-immutable-radix v1.1.0 // indirect
-	github.com/hashicorp/go-plugin v1.0.1
 	github.com/hashicorp/go-retryablehttp v0.6.4 // indirect
 	github.com/hashicorp/go-rootcerts v1.0.2 // indirect
 	github.com/hashicorp/golang-lru v0.5.4 // indirect


### PR DESCRIPTION
```
$ go mod edit -go=1.13
$ go mod tidy
```
At this time,  spiffe/spife  uses go 1.13 (they reverted go1.14 to go1.13).
see: https://github.com/spiffe/spire/pull/1463