### PR TITLE
Deprecate 'tls-auth-mount-point' config value.

### DIFF
--- a/cmd/server/vault-upstream-authority/_test_data/cert-auth-config.tpl
+++ b/cmd/server/vault-upstream-authority/_test_data/cert-auth-config.tpl
@@ -2,7 +2,7 @@ vault_addr  = "{{ .Addr }}"
 pki_mount_point = "test-pki"
 ca_cert_path = "../../../pkg/fake/_test_data/ca.pem"
 cert_auth_config {
-   tls_auth_mount_point = "test-auth"
+   cert_auth_mount_point = "test-auth"
    client_cert_path = "../../../pkg/fake/_test_data/client.pem"
    client_key_path  = "../../../pkg/fake/_test_data/client-key.pem"
 }

--- a/cmd/server/vault-upstream-authority/main.go
+++ b/cmd/server/vault-upstream-authority/main.go
@@ -60,9 +60,12 @@ type VaultTokenAuthConfig struct {
 
 // VaultCertAuthConfig represents parameters for cert auth method
 type VaultCertAuthConfig struct {
-	// Name of mount point where TLS auth method is mounted. (e.g., /auth/<mount_point>/login)
+	// (Deprecated) Name of mount point where TLS auth method is mounted. (e.g., /auth/<mount_point>/login)
 	// If the value is empty, use default mount point (/auth/cert)
 	TLSAuthMountPoint string `hcl:"tls_auth_mount_point"`
+	// Name of mount point where TLS Cert auth method is mounted. (e.g., /auth/<mount_point>/login)
+	// If the value is empty, use default mount point (/auth/cert)
+	CertAuthMountPoint string `hcl:"cert_auth_mount_point"`
 	// Path to a client certificate file.
 	// Only PEM format is supported.
 	ClientCertPath string `hcl:"client_cert_path"`
@@ -132,6 +135,12 @@ func (p *VaultPlugin) Configure(ctx context.Context, req *spi.ConfigureRequest) 
 		}
 	}
 
+	certAuthMountPoint := config.CertAuthConfig.CertAuthMountPoint
+	if config.CertAuthConfig.TLSAuthMountPoint != "" {
+		p.logger.Warn("'tls_auth_mount_point' is deprecated, so use 'cert_auth_mount_point' instead.")
+		certAuthMountPoint = config.CertAuthConfig.TLSAuthMountPoint
+	}
+
 	am, err := parseAuthMethod(config)
 	if err != nil {
 		return nil, err
@@ -144,7 +153,7 @@ func (p *VaultPlugin) Configure(ctx context.Context, req *spi.ConfigureRequest) 
 		CACertPath:            config.CACertPath,
 		Token:                 config.TokenAuthConfig.Token,
 		PKIMountPoint:         config.PKIMountPoint,
-		TLSAuthMountPoint:     config.CertAuthConfig.TLSAuthMountPoint,
+		CertAuthMountPoint:    certAuthMountPoint,
 		ClientKeyPath:         config.CertAuthConfig.ClientKeyPath,
 		ClientCertPath:        config.CertAuthConfig.ClientCertPath,
 		AppRoleAuthMountPoint: config.AppRoleAuthConfig.AppRoleMountPoint,

--- a/cmd/server/vault-upstream-authority/main_test.go
+++ b/cmd/server/vault-upstream-authority/main_test.go
@@ -74,13 +74,13 @@ func getFakeVaultClientWithCertAuth(addr, authMountP, pkiMountP string) (*vault.
 	vaultConfig := vault.New(vault.CERT)
 	retry := 0
 	cp := &vault.ClientParams{
-		MaxRetries:        &retry,
-		VaultAddr:         fmt.Sprintf("https://%v/", addr),
-		CACertPath:        fakeCaCert,
-		TLSAuthMountPoint: authMountP,
-		PKIMountPoint:     pkiMountP,
-		ClientKeyPath:     fakeClientKey,
-		ClientCertPath:    fakeClientCert,
+		MaxRetries:         &retry,
+		VaultAddr:          fmt.Sprintf("https://%v/", addr),
+		CACertPath:         fakeCaCert,
+		CertAuthMountPoint: authMountP,
+		PKIMountPoint:      pkiMountP,
+		ClientKeyPath:      fakeClientKey,
+		ClientCertPath:     fakeClientCert,
 	}
 	if err := vaultConfig.SetClientParams(cp); err != nil {
 		return nil, fmt.Errorf("failetd to prepare vault client")

--- a/cmd/server/vault-upstream-ca/main.go
+++ b/cmd/server/vault-upstream-ca/main.go
@@ -140,7 +140,7 @@ func (p *VaultPlugin) Configure(ctx context.Context, req *spi.ConfigureRequest) 
 		CACertPath:            config.CACertPath,
 		Token:                 config.TokenAuthConfig.Token,
 		PKIMountPoint:         config.PKIMountPoint,
-		TLSAuthMountPoint:     config.CertAuthConfig.TLSAuthMountPoint,
+		CertAuthMountPoint:    config.CertAuthConfig.TLSAuthMountPoint,
 		ClientKeyPath:         config.CertAuthConfig.ClientKeyPath,
 		ClientCertPath:        config.CertAuthConfig.ClientCertPath,
 		AppRoleAuthMountPoint: config.AppRoleAuthConfig.AppRoleMountPoint,

--- a/cmd/server/vault-upstream-ca/main_test.go
+++ b/cmd/server/vault-upstream-ca/main_test.go
@@ -75,13 +75,13 @@ func getFakeVaultClientWithCertAuth(addr, authMountP, pkiMountP string) (*vault.
 	vaultConfig := vault.New(vault.CERT)
 	retry := 0
 	cp := &vault.ClientParams{
-		MaxRetries:        &retry,
-		VaultAddr:         fmt.Sprintf("https://%v/", addr),
-		CACertPath:        fakeCaCert,
-		TLSAuthMountPoint: authMountP,
-		PKIMountPoint:     pkiMountP,
-		ClientKeyPath:     fakeClientKey,
-		ClientCertPath:    fakeClientCert,
+		MaxRetries:         &retry,
+		VaultAddr:          fmt.Sprintf("https://%v/", addr),
+		CACertPath:         fakeCaCert,
+		CertAuthMountPoint: authMountP,
+		PKIMountPoint:      pkiMountP,
+		ClientKeyPath:      fakeClientKey,
+		ClientCertPath:     fakeClientCert,
 	}
 	if err := vaultConfig.SetClientParams(cp); err != nil {
 		return nil, fmt.Errorf("failetd to prepare vault client")

--- a/doc/vault-upstream-authority.md
+++ b/doc/vault-upstream-authority.md
@@ -31,7 +31,8 @@ The Plugin now supports **TLS certificate**, **Token** and **AppRole** authentic
 
 | key | type | required | description | default |
 |:----|:-----|:---------|:------------|:--------|
-| tls_auth_mount_point | string |  | Name of mount point where TLS auth method is mounted | cert |
+| tls_auth_mount_point | string |  | **(Deprecated)** Name of mount point where TLS auth method is mounted | cert |
+| cert_auth_mount_point | string |  | Name of mount point where TLS Cert auth method is mounted | cert |
 | client_cert_path | string | | Path to a client certificate file. Only PEM format is supported. | `${VAULT_CLIENT_CERT}` |
 | client_key_path  | string | | Path to a client private key file. Only PEM format is supported. | `${VAULT_CLIENT_KEY}` |
 
@@ -44,7 +45,7 @@ The Plugin now supports **TLS certificate**, **Token** and **AppRole** authentic
             pki_mount_point = "test-pki"
             ca_cert_path = "/path/to/ca-cert.pem"
             cert_auth_config {
-                tls_auth_mount_point = "test-tls-auth"
+                cert_auth_mount_point = "test-tls-auth"
                 client_cert_path = "/path/to/client-cert.pem"
                 client_key_path  = "/path/to/client-key.pem"
             }

--- a/pkg/vault/vault.go
+++ b/pkg/vault/vault.go
@@ -62,8 +62,8 @@ type ClientParams struct {
 	PKIMountPoint string
 	// token string to use when auth method is 'token'
 	Token string
-	// Name of mount point where TLS auth method is mounted. (e.g., /auth/<mount_point>/login )
-	TLSAuthMountPoint string
+	// Name of mount point where TLS Cert auth method is mounted. (e.g., /auth/<mount_point>/login )
+	CertAuthMountPoint string
 	// Path to a client certificate file to be used when auth method is 'cert'
 	ClientCertPath string
 	// Path to a client private key file to be used when auth method is 'cert'
@@ -106,7 +106,7 @@ func New(authMethod AuthMethod) *Config {
 		Logger: hclog.New(hclog.DefaultOptions),
 		method: authMethod,
 		clientParams: &ClientParams{
-			TLSAuthMountPoint:     DefaultCertMountPoint,
+			CertAuthMountPoint:    DefaultCertMountPoint,
 			AppRoleAuthMountPoint: DefaultAppRoleMountPoint,
 			PKIMountPoint:         DefaultPKIMountPoint,
 		},
@@ -166,7 +166,7 @@ func (c *Config) NewAuthenticatedClient() (*Client, error) {
 	case TOKEN:
 		client.SetToken(c.clientParams.Token)
 	case CERT:
-		path := fmt.Sprintf("auth/%v/login", c.clientParams.TLSAuthMountPoint)
+		path := fmt.Sprintf("auth/%v/login", c.clientParams.CertAuthMountPoint)
 		sec, err := client.Auth(path, map[string]interface{}{})
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
This PR adds the new config value `cert-auth-mount-point`.
The new parameter is an alternative to `tls-auth-mount-point`.
So `tls-auth-mount-point` is deprecated after this PR is merged.